### PR TITLE
Add file-based message history feature to Chat class

### DIFF
--- a/kairix-engine/.gitignore
+++ b/kairix-engine/.gitignore
@@ -1,0 +1,24 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+env/
+venv/
+.venv/
+*.egg-info/
+dist/
+build/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+.DS_Store
+
+# Project specific
+chat_logs/
+*.log
+.env

--- a/kairix-engine/gradio_chat.py
+++ b/kairix-engine/gradio_chat.py
@@ -1,0 +1,99 @@
+import logging
+
+import gradio as gr
+from agents import Runner
+from cognition_engine.perceptor.conversation_remembering_perceptor import (
+    ConversationRememberingPerceptor,
+)
+
+from kairix_engine.basic_chat import Chat
+from kairix_engine.summary_store import SummaryStore
+
+NEO4J_URL = "bolt://neo4j:password@cayucos.thrush-escalator.ts.net:7687"
+
+# Configure logging
+logging.basicConfig(level=logging.WARNING)
+logging.getLogger("kairix_engine").setLevel(logging.INFO)
+logging.getLogger("cognition_engine").setLevel(logging.INFO)
+
+# Initialize components
+store = SummaryStore(store_url=NEO4J_URL)
+perceptor = ConversationRememberingPerceptor(
+    Runner(),
+    memory_provider=lambda query, k: [
+        content for content, score in store.search(query, k)
+    ],
+    k_memories=10,
+)
+chat = Chat(user_name="Mark", agent_name="Apiana", perceptor=perceptor)
+
+# Flag to track initialization
+_initialized = False
+
+
+async def ensure_initialized():
+    """Ensure chat is initialized."""
+    global _initialized
+    if not _initialized:
+        await chat.initialize()
+        _initialized = True
+
+
+async def respond(message, history):
+    await ensure_initialized()
+    """Stream responses from the chat engine"""
+    history = history or []
+    history.append({"role": "user", "content": message})
+    history.append({"role": "assistant", "content": ""})
+    
+    full_response = ""
+    
+    # Use the streaming run() method
+    async for chunk in chat.run(message):
+        full_response += chunk
+        history[-1]["content"] = full_response
+        yield "", history
+
+
+# Create Gradio interface with custom CSS for compact layout
+with gr.Blocks(
+    title="Kairix Chat",
+    css="""
+    .contain { max-width: 900px !important; }
+    footer { display: none !important; }
+    #component-0 { height: calc(100vh - 200px) !important; }
+    .message-wrap { padding: 8px !important; }
+    """
+) as demo, gr.Column():
+    chatbot = gr.Chatbot(
+        height=450,
+        bubble_full_width=False,
+        avatar_images=(None, "🐝"),
+        show_label=False,
+        elem_id="component-0",
+        autoscroll=True,  # Always scroll to bottom
+        type="messages",  # Use openai-style format
+    )
+    
+    with gr.Row():
+        msg = gr.Textbox(
+            placeholder="Message Apiana... (Enter to send, Shift+Enter for new line)",
+            lines=1,
+            max_lines=3,
+            show_label=False,
+            autofocus=True,
+        )
+        
+        clear = gr.Button("Clear", scale=0, min_width=60)
+    
+    # Handle message submission with streaming
+    msg.submit(respond, [msg, chatbot], [msg, chatbot])
+    clear.click(lambda: (None, None), outputs=[msg, chatbot])
+
+
+if __name__ == "__main__":
+    demo.launch(
+        server_name="0.0.0.0",
+        server_port=7860,
+        share=False,
+    )

--- a/kairix-engine/pyproject.toml
+++ b/kairix-engine/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.10,<3.11"
 dependencies = [
+    "aiofiles>=24.1.0",
     "cognition-engine",
     "gradio>=5.33.2",
     "kairix-core",
@@ -13,6 +14,8 @@ dependencies = [
     "openai>=1.86.0",
     "openai-agents>=0.0.17",
     "openai-swarm>=0.1.1",
+    "pydantic>=2.11.7",
+    "pyyaml>=6.0.2",
     "sentence-transformers>=4.1.0",
     "sounddevice>=0.5.2",
     "textual>=3.3.0",
@@ -98,6 +101,8 @@ dev = [
     "mypy>=1.16.0",
     "pytest-asyncio>=1.0.0",
     "textual-dev>=1.7.0",
+    "types-aiofiles>=24.1.0.20250606",
+    "types-pyyaml>=6.0.12.20250516",
 ]
 
 [tool.uv.sources]

--- a/kairix-engine/src/kairix_engine/message_history.py
+++ b/kairix-engine/src/kairix_engine/message_history.py
@@ -1,0 +1,138 @@
+import asyncio
+import datetime
+import logging
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+class MessageHistory:
+    """Handles persistent storage of chat message history in YAML format."""
+    
+    def __init__(
+        self,
+        log_dir: str = "chat_logs",
+        max_context_pairs: int = 10
+    ):
+        """
+        Initialize message history handler.
+        
+        Args:
+            log_dir: Directory for storing daily chat logs
+            max_context_pairs: Number of recent message pairs to load on startup
+        """
+        self.log_dir = Path(log_dir)
+        self.log_dir.mkdir(exist_ok=True)
+        self.max_context_pairs = max_context_pairs
+        self._file: Any | None = None  # aiofiles typing is incomplete
+        self._write_lock = asyncio.Lock()
+        
+        # Create today's file and open it
+        today = datetime.date.today()
+        self._filename = self.log_dir / f"chat_{today.strftime('%Y-%m-%d')}.yaml"
+        
+    async def start(self) -> None:
+        """Open the log file for writing."""
+        # If file doesn't exist, create with header
+        if not self._filename.exists():
+            async with aiofiles.open(self._filename, 'w') as f:
+                await f.write("messages:\n")
+        
+        # Open file in append mode
+        self._file = await aiofiles.open(self._filename, 'a')
+        
+    async def stop(self) -> None:
+        """Close the file handle."""
+        if self._file:
+            await self._file.close()
+            self._file = None
+            
+    async def append_message_pair(self, user_msg: str, assistant_msg: str) -> None:
+        """
+        Append a message pair to the log file.
+        
+        Args:
+            user_msg: User's message
+            assistant_msg: Assistant's response
+        """
+        message = {
+            "timestamp": datetime.datetime.utcnow().isoformat() + "Z",
+            "user": user_msg,
+            "assistant": assistant_msg
+        }
+        
+        # Fire and forget the write operation
+        asyncio.create_task(  # type: ignore[unused-awaitable]  # noqa: RUF006
+            self._write_message_async(message)
+        )
+        
+    async def load_recent_context(self) -> list[dict[str, str]]:
+        """
+        Load the most recent message pairs from history.
+        
+        Returns:
+            List of message dictionaries
+        """
+        # Get list of log files sorted by date (newest first)
+        log_files = sorted(self.log_dir.glob("chat_*.yaml"), reverse=True)
+        
+        all_messages: list[dict[str, str]] = []
+        
+        # Read messages from files until we have enough
+        for log_file in log_files:
+            try:
+                async with aiofiles.open(log_file) as f:
+                    content = await f.read()
+                    data = yaml.safe_load(content) or {}
+                    messages = data.get("messages", [])
+                    
+                    # Prepend messages (newer files first)
+                    all_messages = messages + all_messages
+                    
+                    # Stop if we have enough messages
+                    if len(all_messages) >= self.max_context_pairs:
+                        return all_messages[-self.max_context_pairs:]
+                        
+            except Exception as e:
+                logger.error(f"Error loading messages from {log_file}: {e}")
+                continue
+                
+        return all_messages
+            
+    async def _write_message_async(self, message: dict[str, str]) -> None:
+        """
+        Write a message to the log file.
+        
+        Args:
+            message: Message dictionary to write
+        """
+        try:
+            # Log the message pair at debug level
+            logger.debug(
+                f"Writing message pair - User: {message['user']} | "
+                f"Assistant: {message['assistant']}"
+            )
+            
+            async with self._write_lock:
+                if self._file:
+                    # Format message as YAML list item
+                    yaml_entry = (
+                        f"  - timestamp: \"{message['timestamp']}\"\n"
+                        f"    user: \"{message['user']}\"\n"
+                        f"    assistant: \"{message['assistant']}\"\n"
+                    )
+                    
+                    # Write and flush
+                    await self._file.write(yaml_entry)
+                    await self._file.flush()
+                    
+        except Exception as e:
+            # Log each message on its own line as error
+            logger.error(f"Failed to write message pair to file: {e}")
+            logger.error(f"User message: {message['user']}")
+            logger.error(f"Assistant message: {message['assistant']}")
+            # Don't re-raise to prevent losing messages

--- a/kairix-engine/tests/test_message_history.py
+++ b/kairix-engine/tests/test_message_history.py
@@ -1,0 +1,317 @@
+import asyncio
+import datetime
+
+import aiofiles
+import pytest
+import pytest_asyncio
+import yaml
+
+from kairix_engine.message_history import MessageHistory
+
+
+@pytest_asyncio.fixture
+async def message_history(tmp_path, monkeypatch):
+    """Create a MessageHistory instance with a temporary directory."""
+    # Mock date for consistent filenames
+    fixed_date = datetime.date(2025, 1, 15)
+    
+    class MockDate:
+        @staticmethod
+        def today():
+            return fixed_date
+    
+    monkeypatch.setattr("datetime.date", MockDate)
+    
+    history = MessageHistory(log_dir=str(tmp_path / "chat_logs"))
+    await history.start()
+    yield history
+    await history.stop()
+
+
+@pytest.fixture
+def mock_today(monkeypatch):
+    """Mock datetime.date.today to return a fixed date."""
+    fixed_date = datetime.date(2025, 1, 15)
+    
+    class MockDate:
+        @staticmethod
+        def today():
+            return fixed_date
+    
+    monkeypatch.setattr("datetime.date", MockDate)
+    return fixed_date
+
+
+@pytest.mark.asyncio
+async def test_init_creates_log_directory(tmp_path):
+    """Test that initialization creates the log directory."""
+    log_dir = tmp_path / "chat_logs"
+    assert not log_dir.exists()
+    
+    MessageHistory(log_dir=str(log_dir))
+    assert log_dir.exists()
+    assert log_dir.is_dir()
+
+
+@pytest.mark.asyncio
+async def test_append_message_pair(message_history):
+    """Test appending a message pair writes to log file."""
+    await message_history.append_message_pair("Hello", "Hi there!")
+    
+    # Give the background task time to write
+    await asyncio.sleep(0.1)
+    
+    # Check the file exists
+    expected_file = message_history._filename
+    assert expected_file.exists()
+    
+    # Verify content
+    async with aiofiles.open(expected_file) as f:
+        content = await f.read()
+        data = yaml.safe_load(content)
+        
+    assert "messages" in data
+    assert len(data["messages"]) == 1
+    assert data["messages"][0]["user"] == "Hello"
+    assert data["messages"][0]["assistant"] == "Hi there!"
+    assert "timestamp" in data["messages"][0]
+
+
+@pytest.mark.asyncio
+async def test_multiple_messages_same_file(message_history):
+    """Test that multiple messages append to the same file."""
+    await message_history.append_message_pair("First", "Response 1")
+    await message_history.append_message_pair("Second", "Response 2")
+    
+    await asyncio.sleep(0.1)
+    
+    expected_file = message_history._filename
+    
+    async with aiofiles.open(expected_file) as f:
+        content = await f.read()
+        data = yaml.safe_load(content)
+        
+    assert len(data["messages"]) == 2
+    assert data["messages"][0]["user"] == "First"
+    assert data["messages"][1]["user"] == "Second"
+
+
+@pytest.mark.asyncio
+async def test_load_recent_context_empty(message_history):
+    """Test loading context when no history exists."""
+    context = await message_history.load_recent_context()
+    assert context == []
+
+
+@pytest.mark.asyncio
+async def test_load_recent_context_single_file(message_history):
+    """Test loading context from current session's file."""
+    # Write some messages
+    for i in range(5):
+        await message_history.append_message_pair(f"User {i}", f"Assistant {i}")
+    
+    await asyncio.sleep(0.1)
+    
+    # Load context
+    context = await message_history.load_recent_context()
+    assert len(context) == 5
+    assert context[0]["user"] == "User 0"
+    assert context[4]["user"] == "User 4"
+
+
+@pytest.mark.asyncio
+async def test_load_recent_context_max_pairs(message_history):
+    """Test that load_recent_context respects max_context_pairs."""
+    # Create history with max 3 pairs
+    history = MessageHistory(
+        log_dir=str(message_history.log_dir),
+        max_context_pairs=3
+    )
+    await history.start()
+    
+    # Write 10 messages
+    for i in range(10):
+        await message_history.append_message_pair(f"User {i}", f"Assistant {i}")
+    
+    await asyncio.sleep(0.1)
+    
+    # Load context - should only get last 3
+    context = await history.load_recent_context()
+    assert len(context) == 3
+    assert context[0]["user"] == "User 7"
+    assert context[2]["user"] == "User 9"
+    
+    await history.stop()
+
+
+@pytest.mark.asyncio
+async def test_load_recent_context_multiple_files(tmp_path):
+    """Test loading context across multiple daily files."""
+    log_dir = tmp_path / "chat_logs"
+    log_dir.mkdir()
+    
+    # Create files for different days
+    for day in range(1, 4):
+        date = datetime.date(2025, 1, day)
+        file_path = log_dir / f"chat_{date.strftime('%Y-%m-%d')}.yaml"
+        
+        messages = []
+        for i in range(3):
+            messages.append({
+                "timestamp": f"2025-01-{day:02d}T10:{i:02d}:00Z",
+                "user": f"Day {day} User {i}",
+                "assistant": f"Day {day} Assistant {i}"
+            })
+        
+        async with aiofiles.open(file_path, 'w') as f:
+            await f.write(yaml.dump({"messages": messages}))
+    
+    # Load with max 5 pairs
+    history = MessageHistory(log_dir=str(log_dir), max_context_pairs=5)
+    context = await history.load_recent_context()
+    
+    # Should get last 5 messages: all 3 from day 3, and 2 from day 2
+    assert len(context) == 5
+    assert context[0]["user"] == "Day 2 User 1"  # First of the 5 most recent
+    assert context[1]["user"] == "Day 2 User 2"
+    assert context[2]["user"] == "Day 3 User 0"
+    assert context[3]["user"] == "Day 3 User 1"
+    assert context[4]["user"] == "Day 3 User 2"  # Most recent
+
+
+@pytest.mark.asyncio
+async def test_file_created_on_start(tmp_path, monkeypatch):
+    """Test that file is created with header on start."""
+    # Mock date
+    fixed_date = datetime.date(2025, 1, 20)
+    
+    class MockDate:
+        @staticmethod
+        def today():
+            return fixed_date
+    
+    monkeypatch.setattr("datetime.date", MockDate)
+    
+    history = MessageHistory(log_dir=str(tmp_path / "chat_logs"))
+    expected_file = history._filename
+    
+    # File shouldn't exist yet
+    assert not expected_file.exists()
+    
+    # Start should create file with header
+    await history.start()
+    assert expected_file.exists()
+    
+    async with aiofiles.open(expected_file) as f:
+        content = await f.read()
+    
+    assert content == "messages:\n"
+    
+    await history.stop()
+
+
+@pytest.mark.asyncio
+async def test_error_handling_corrupted_file(tmp_path):
+    """Test that corrupted files don't break loading."""
+    log_dir = tmp_path / "chat_logs"
+    log_dir.mkdir()
+    
+    # Create a corrupted file
+    bad_file = log_dir / "chat_2025-01-15.yaml"
+    async with aiofiles.open(bad_file, 'w') as f:
+        await f.write("{ invalid yaml content")
+    
+    history = MessageHistory(log_dir=str(log_dir))
+    
+    # Should return empty list and not crash
+    context = await history.load_recent_context()
+    assert context == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes(message_history):
+    """Test that concurrent writes are handled correctly."""
+    # Send many messages concurrently
+    tasks = []
+    for i in range(10):
+        task = message_history.append_message_pair(f"Concurrent {i}", f"Response {i}")
+        tasks.append(task)
+    
+    await asyncio.gather(*tasks)
+    await asyncio.sleep(0.2)
+    
+    # Verify all messages were written
+    expected_file = message_history._filename
+    async with aiofiles.open(expected_file) as f:
+        content = await f.read()
+        data = yaml.safe_load(content)
+    
+    assert len(data["messages"]) == 10
+    user_messages = [msg["user"] for msg in data["messages"]]
+    for i in range(10):
+        assert f"Concurrent {i}" in user_messages
+
+
+@pytest.mark.asyncio
+async def test_non_blocking_writes(message_history, caplog):
+    """Test that writes don't block the main execution."""
+    import logging
+    import time
+    
+    # Set log level to debug to capture debug messages
+    caplog.set_level(logging.DEBUG)
+    
+    # Time how long append_message_pair takes
+    start = time.time()
+    await message_history.append_message_pair("Test", "Response")
+    duration = time.time() - start
+    
+    # Should return almost immediately (< 10ms)
+    assert duration < 0.01
+    
+    # Wait for write to complete
+    await asyncio.sleep(0.1)
+    
+    # Check debug log was written
+    assert "Writing message pair - User: Test | Assistant: Response" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_write_error_logging(tmp_path, caplog, monkeypatch):
+    """Test that write errors log both messages separately."""
+    import logging
+    
+    # Set log level to capture errors
+    caplog.set_level(logging.ERROR)
+    
+    # Mock date
+    fixed_date = datetime.date(2025, 1, 15)
+    
+    class MockDate:
+        @staticmethod
+        def today():
+            return fixed_date
+    
+    monkeypatch.setattr("datetime.date", MockDate)
+    
+    history = MessageHistory(log_dir=str(tmp_path / "chat_logs"))
+    await history.start()
+    
+    # Close the file to cause write error
+    if history._file:
+        await history._file.close()
+    
+    # Try to write - should fail but not crash
+    await history.append_message_pair("Test message", "Test response")
+    
+    # Wait for write attempt
+    await asyncio.sleep(0.1)
+    
+    # Check error logs
+    assert "Failed to write message pair to file" in caplog.text
+    assert "User message: Test message" in caplog.text
+    assert "Assistant message: Test response" in caplog.text
+    
+    # Cleanup
+    history._file = None
+    await history.stop()

--- a/kairix-engine/tests/unit/test_chat_history_integration.py
+++ b/kairix-engine/tests/unit/test_chat_history_integration.py
@@ -1,0 +1,183 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import pytest_asyncio
+import yaml
+
+from kairix_engine.basic_chat import Chat
+
+
+@pytest.fixture
+def mock_perceptor():
+    """Fixture providing a mock perceptor"""
+    perceptor = Mock()
+    perceptor.perceive = AsyncMock(return_value=[])
+    return perceptor
+
+
+@pytest_asyncio.fixture
+async def chat_with_history(mock_perceptor, tmp_path):
+    """Fixture providing a Chat instance with message history enabled"""
+    chat_instance = Chat(
+        user_name="TestUser",
+        agent_name="TestAgent",
+        perceptor=mock_perceptor,
+        enable_history=True,
+        history_log_dir=str(tmp_path / "chat_logs"),
+        max_context_pairs=5
+    )
+    await chat_instance.initialize()
+    yield chat_instance
+    await chat_instance.close()
+
+
+class TestChatHistoryIntegration:
+    """Test cases for Chat with MessageHistory integration"""
+
+    @pytest.mark.asyncio
+    @patch("kairix_engine.basic_chat.Runner")
+    async def test_chat_persists_messages(self, mock_runner, chat_with_history):
+        """Test that chat messages are persisted to file"""
+        # Setup
+        test_input = "Hello, how are you?"
+        expected_response = "I'm doing well, thank you!"
+        
+        mock_result = Mock()
+        mock_result.final_output_as.return_value = expected_response
+        mock_runner.run = AsyncMock(return_value=mock_result)
+        
+        # Execute
+        await chat_with_history.chat(test_input)
+        
+        # Wait for async write
+        import asyncio
+        await asyncio.sleep(0.1)
+        
+        # Verify message was persisted
+        log_file = next(
+            chat_with_history.message_history._filename.parent.glob("*.yaml")
+        )
+        import aiofiles
+        async with aiofiles.open(log_file) as f:
+            content = await f.read()
+            data = yaml.safe_load(content)
+        
+        assert len(data["messages"]) == 1
+        assert data["messages"][0]["user"] == test_input
+        assert data["messages"][0]["assistant"] == expected_response
+
+    @pytest.mark.asyncio
+    @patch("kairix_engine.basic_chat.Runner")
+    @patch("kairix_engine.basic_chat.VoiceWorkflowHelper")
+    async def test_run_persists_messages(
+        self, mock_helper, mock_runner, chat_with_history
+    ):
+        """Test that run() streaming method persists messages"""
+        # Setup
+        test_input = "Tell me a story"
+        expected_response = "Once upon a time..."
+        
+        mock_result = Mock()
+        mock_result.final_output_as.return_value = expected_response
+        mock_runner.run_streamed.return_value = mock_result
+        
+        # Mock streaming
+        async def mock_stream(*args):
+            yield "Once "
+            yield "upon "
+            yield "a time..."
+        
+        mock_helper.stream_text_from.return_value = mock_stream()
+        
+        # Execute
+        chunks = []
+        async for chunk in chat_with_history.run(test_input):
+            chunks.append(chunk)
+        
+        # Wait for async write
+        import asyncio
+        await asyncio.sleep(0.1)
+        
+        # Verify message was persisted
+        log_file = next(
+            chat_with_history.message_history._filename.parent.glob("*.yaml")
+        )
+        import aiofiles
+        async with aiofiles.open(log_file) as f:
+            content = await f.read()
+            data = yaml.safe_load(content)
+        
+        assert len(data["messages"]) == 1
+        assert data["messages"][0]["user"] == test_input
+        assert data["messages"][0]["assistant"] == expected_response
+
+    @pytest.mark.asyncio
+    @patch("kairix_engine.basic_chat.Runner")
+    async def test_chat_loads_history_on_init(
+        self, mock_runner, mock_perceptor, tmp_path
+    ):
+        """Test that chat loads previous messages on initialization"""
+        # Create a history file with existing messages
+        log_dir = tmp_path / "chat_logs"
+        log_dir.mkdir()
+        
+        import datetime
+        today = datetime.date.today()
+        log_file = log_dir / f"chat_{today.strftime('%Y-%m-%d')}.yaml"
+        
+        existing_messages = {
+            "messages": [
+                {
+                    "timestamp": "2025-01-15T10:00:00Z",
+                    "user": "Previous question",
+                    "assistant": "Previous answer"
+                },
+                {
+                    "timestamp": "2025-01-15T10:01:00Z",
+                    "user": "Another question",
+                    "assistant": "Another answer"
+                }
+            ]
+        }
+        
+        import aiofiles
+        async with aiofiles.open(log_file, 'w') as f:
+            await f.write(yaml.dump(existing_messages))
+        
+        # Create chat instance
+        chat = Chat(
+            user_name="TestUser",
+            agent_name="TestAgent",
+            perceptor=mock_perceptor,
+            enable_history=True,
+            history_log_dir=str(log_dir),
+            max_context_pairs=10
+        )
+        
+        await chat.initialize()
+        
+        # Verify history was loaded
+        assert len(chat.history) == 4  # 2 user + 2 assistant messages
+        assert chat.history[0].content == "Previous question"
+        assert chat.history[1].content == "Previous answer"
+        assert chat.history[2].content == "Another question"
+        assert chat.history[3].content == "Another answer"
+        
+        await chat.close()
+
+    @pytest.mark.asyncio
+    async def test_chat_without_history(self, mock_perceptor):
+        """Test that chat works with history disabled"""
+        chat = Chat(
+            user_name="TestUser",
+            agent_name="TestAgent",
+            perceptor=mock_perceptor,
+            enable_history=False
+        )
+        
+        await chat.initialize()
+        
+        # Verify no message history was created
+        assert chat.message_history is None
+        
+        await chat.close()

--- a/kairix-engine/tests/unit/test_chat_method.py
+++ b/kairix-engine/tests/unit/test_chat_method.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import pytest_asyncio
 
 from kairix_engine.basic_chat import Chat, KairixMessage
 
@@ -13,14 +14,18 @@ def mock_perceptor():
     return perceptor
 
 
-@pytest.fixture
-def chat(mock_perceptor):
+@pytest_asyncio.fixture
+async def chat(mock_perceptor):
     """Fixture providing a Chat instance with mocked dependencies"""
-    return Chat(
+    chat_instance = Chat(
         user_name="TestUser",
         agent_name="TestAgent",
-        perceptor=mock_perceptor
+        perceptor=mock_perceptor,
+        enable_history=False  # Disable file history for tests
     )
+    await chat_instance.initialize()
+    yield chat_instance
+    await chat_instance.close()
 
 
 class TestChatMethod:

--- a/kairix-engine/tests/unit/test_chat_run_method.py
+++ b/kairix-engine/tests/unit/test_chat_run_method.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import pytest_asyncio
 
 from kairix_engine.basic_chat import Chat
 
@@ -13,14 +14,18 @@ def mock_perceptor():
     return perceptor
 
 
-@pytest.fixture
-def chat(mock_perceptor):
+@pytest_asyncio.fixture
+async def chat(mock_perceptor):
     """Fixture providing a Chat instance with mocked dependencies"""
-    return Chat(
+    chat_instance = Chat(
         user_name="TestUser",
         agent_name="TestAgent",
-        perceptor=mock_perceptor
+        perceptor=mock_perceptor,
+        enable_history=False  # Disable file history for tests
     )
+    await chat_instance.initialize()
+    yield chat_instance
+    await chat_instance.close()
 
 
 class TestChatRunMethod:

--- a/kairix-engine/uv.lock
+++ b/kairix-engine/uv.lock
@@ -154,11 +154,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.4.26"
+version = "2025.6.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/f7/f14b46d4bcd21092d7d3ccef689615220d8a08fb25e564b65d20738e672e/certifi-2025.6.15.tar.gz", hash = "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b", size = 158753, upload-time = "2025-06-15T02:45:51.329Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ae/320161bd181fc06471eed047ecce67b693fd7515b16d495d8932db763426/certifi-2025.6.15-py3-none-any.whl", hash = "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057", size = 157650, upload-time = "2025-06-15T02:45:49.977Z" },
 ]
 
 [[package]]
@@ -774,6 +774,7 @@ name = "kairix-engine"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiofiles" },
     { name = "cognition-engine" },
     { name = "gradio" },
     { name = "kairix-core" },
@@ -782,6 +783,8 @@ dependencies = [
     { name = "openai" },
     { name = "openai-agents" },
     { name = "openai-swarm" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
     { name = "sentence-transformers" },
     { name = "sounddevice" },
     { name = "textual" },
@@ -807,10 +810,13 @@ dev = [
     { name = "mypy" },
     { name = "pytest-asyncio" },
     { name = "textual-dev" },
+    { name = "types-aiofiles" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "cognition-engine", editable = "../cognition_engine" },
     { name = "gradio", specifier = ">=5.33.2" },
     { name = "ipython", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -821,10 +827,12 @@ requires-dist = [
     { name = "openai", specifier = ">=1.86.0" },
     { name = "openai-agents", specifier = ">=0.0.17" },
     { name = "openai-swarm", specifier = ">=0.1.1" },
+    { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.350" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "python-lsp-server", marker = "extra == 'dev'", specifier = ">=1.11.0" },
+    { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "ruff-lsp", marker = "extra == 'dev'", specifier = ">=0.0.53" },
     { name = "sentence-transformers", specifier = ">=4.1.0" },
@@ -841,6 +849,8 @@ dev = [
     { name = "mypy", specifier = ">=1.16.0" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "textual-dev", specifier = ">=1.7.0" },
+    { name = "types-aiofiles", specifier = ">=24.1.0.20250606" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250516" },
 ]
 
 [[package]]
@@ -2299,6 +2309,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "24.1.0.20250606"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/6e/fac4ffc896cb3faf2ac5d23747b65dd8bae1d9ee23305d1a3b12111c3989/types_aiofiles-24.1.0.20250606.tar.gz", hash = "sha256:48f9e26d2738a21e0b0f19381f713dcdb852a36727da8414b1ada145d40a18fe", size = 14364, upload-time = "2025-06-06T03:09:26.515Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/de/f2fa2ab8a5943898e93d8036941e05bfd1e1f377a675ee52c7c307dccb75/types_aiofiles-24.1.0.20250606-py3-none-any.whl", hash = "sha256:e568c53fb9017c80897a9aa15c74bf43b7ee90e412286ec1e0912b6e79301aee", size = 14276, upload-time = "2025-06-06T03:09:25.662Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/22/59e2aeb48ceeee1f7cd4537db9568df80d62bdb44a7f9e743502ea8aab9c/types_pyyaml-6.0.12.20250516.tar.gz", hash = "sha256:9f21a70216fc0fa1b216a8176db5f9e0af6eb35d2f2932acb87689d03a5bf6ba", size = 17378, upload-time = "2025-05-16T03:08:04.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5f/e0af6f7f6a260d9af67e1db4f54d732abad514252a7a378a6c4d17dd1036/types_pyyaml-6.0.12.20250516-py3-none-any.whl", hash = "sha256:8478208feaeb53a34cb5d970c56a7cd76b72659442e733e268a94dc72b2d0530", size = 20312, upload-time = "2025-05-16T03:08:04.019Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds file-based message history with YAML persistence to the Chat class
- Implements async non-blocking writes to avoid blocking the chat loop
- Loads recent context (last 10 messages, configurable) on startup

## Implementation Details
- Created `MessageHistory` class that handles all file I/O operations
- Uses fire-and-forget pattern with `asyncio.create_task()` for non-blocking writes
- Writes user/assistant message pairs to YAML files in `chat_logs/` directory
- One file per program run, named by start date (e.g., `chat_2025-01-15.yaml`)
- Keeps file handle open during runtime for efficient appending
- Integrated directly into Chat class with `enable_history` parameter (default: True)

## Error Handling
- Debug level logs for successful message pair writes
- Error logs for write failures (logs both messages on separate lines)
- Graceful handling of corrupted YAML files during load
- Non-critical failures don't block chat functionality

## Testing
- Comprehensive unit tests for MessageHistory class
- Integration tests for Chat class with history enabled/disabled
- Tests for concurrent writes, error handling, and non-blocking behavior
- All tests pass with `just all`

## Test plan
- [x] Run existing chat tests to ensure no regression
- [x] Test new message history functionality
- [x] Verify non-blocking writes don't delay chat responses
- [x] Check that history loads correctly on startup
- [x] Ensure graceful handling of write errors

🤖 Generated with [Claude Code](https://claude.ai/code)